### PR TITLE
fix/syncVectorRender

### DIFF
--- a/source/painters/DomPainter/LayerRenderer.ts
+++ b/source/painters/DomPainter/LayerRenderer.ts
@@ -173,13 +173,31 @@ export class LayerRenderer {
 
         this._removeOutdatedRenders(renders);
 
-        this._draw(renders);
+        const vectorImages = renders.filter(r => r instanceof StaticVectorImageRender);
 
-        if (!this._canvas.isEmpty) {
-            this._addCanvasToDom(bbox);
+        if (vectorImages.length > 0 && renders.length !== vectorImages.length) {
+            this._drawVectorSync(renders, vectorImages, bbox)
+        } else {
+            this._draw(renders);
+
+            if (!this._canvas.isEmpty) {
+                this._addCanvasToDom(bbox);
+            }
+
+            this._renders = renders;
         }
+    }
 
-        this._renders = renders;
+    private _drawVectorSync(renders: Render[], images: Render[], bbox: Bbox) {
+        Promise.all(images.map(({ readyPromise }: StaticVectorImageRender) => readyPromise)).then(() => {
+            this._draw(renders);
+
+            if (!this._canvas.isEmpty) {
+                this._addCanvasToDom(bbox);
+            }
+
+            this._renders = renders;
+        });
     }
 
     private _draw(renders: Render[]): void {


### PR DESCRIPTION
При отрисовке векторного символа где содержатся изображения вместе с рендерами arc, label итд, изображения рисуются поверх векторов из-за того что рендер происходит асинхронно и при рендере порядок в массиве нарушается.
```
renderFunction(feature, resolution, crs) {
  const renders = [
    new StaticVectorImageRender(),
    new StaticVectorImageRender(),
    new Arc(),
    new VectorLabel(),
  ];

  return renders;
}
```
Как есть
![bug](https://user-images.githubusercontent.com/10591102/100071059-4b8ab480-2e43-11eb-906e-2a919e4e0233.png)
Как должно быть
![fix](https://user-images.githubusercontent.com/10591102/100071118-5e04ee00-2e43-11eb-966d-2c89f67b293b.png)

